### PR TITLE
create aframe element instead of aframe-react Entity

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -5,8 +5,6 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.Videosphere = exports.Curvedimage = exports.VideoSphere = exports.Video = exports.Torus = exports.TorusKnot = exports.Tetrahedron = exports.Sphere = exports.Sound = exports.Sky = exports.Ring = exports.Plane = exports.Octahedron = exports.ObjModel = exports.Light = exports.Image = exports.Dodecahedron = exports.Cylinder = exports.CurvedImage = exports.Cursor = exports.Cone = exports.ColladaModel = exports.Circle = exports.Camera = exports.Box = exports.Animation = undefined;
 
-var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
-
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -23,9 +21,9 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 var OMIT_PROPS = ['primitive'];
 
-var renderEntityWithPrimitive = function renderEntityWithPrimitive(name) {
+var renderEntityWithPrimitive = function renderEntityWithPrimitive(primitive) {
   return function (props) {
-    return _react2.default.createElement(_aframeReact.Entity, _extends({ primitive: name }, (0, _utils.omit)(props, OMIT_PROPS)));
+    return _react2.default.createElement(primitive, props);
   };
 };
 

--- a/src/components.js
+++ b/src/components.js
@@ -59,6 +59,9 @@ export default {
   Tetrahedron: {
     primitive: 'a-tetrahedron',
   },
+  Text: {
+    primitive: 'a-text',
+  },
   TorusKnot: {
     primitive: 'a-torus-knot',
   },

--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,8 @@ import componentsData from './components';
 
 const OMIT_PROPS = ['primitive'];
 
-const renderEntityWithPrimitive = name => props =>
-  <Entity primitive={name} {...omit(props, OMIT_PROPS)} />;
+const renderEntityWithPrimitive = primitive => props =>
+  React.createElement(primitive, props);
 
 const Components = Object.keys(componentsData).reduce((result, compName) => {
   const compData = componentsData[compName];
@@ -38,6 +38,7 @@ export const Sky = Components.Sky;
 export const Sound = Components.Sound;
 export const Sphere = Components.Sphere;
 export const Tetrahedron = Components.Tetrahedron;
+export const Text = Components.Text;
 export const TorusKnot = Components.TorusKnot;
 export const Torus = Components.Torus;
 export const Video = Components.Video;


### PR DESCRIPTION
instead of proxying props through `<Entity />` we can just return an aframe element that accepts all the props the primitives accept.

I was thinking about creating react components for the primitives when I saw this library. :+1: 